### PR TITLE
Add option to disable visual key press feedback

### DIFF
--- a/qml/Keyboard.qml
+++ b/qml/Keyboard.qml
@@ -36,6 +36,8 @@ Item {
 
     property bool active
 
+    property bool showVisualKeyPressFeedback: util.showVisualKeyPressFeedback
+
     property int outmargins: util.keyboardMargins
     property int keyspacing: 6
     property int keysPerRow: keyLoader.vkbColumns()
@@ -98,7 +100,7 @@ Item {
                             && currentKeyPressed.currentLabel !== " ")
                            ? currentKeyPressed : null
 
-        visible: _key || visualFeedbackDelay.running
+        visible: (_key || visualFeedbackDelay.running) && showVisualKeyPressFeedback
         radius: window.radiusSmall
         color: keyFgColor
 

--- a/util.cpp
+++ b/util.cpp
@@ -300,6 +300,11 @@ int Util::keyboardMargins()
     return settingsValue("ui/keyboardMargins", 10).toInt();
 }
 
+bool Util::showVisualKeyPressFeedback()
+{
+    return settingsValue("ui/showVisualKeyPressFeedback", true).toBool();
+}
+
 int Util::orientationMode()
 {
     QString mode = settingsValue("ui/orientationLockMode", "auto").toString();

--- a/util.h
+++ b/util.h
@@ -43,6 +43,7 @@ class Util : public QObject
     Q_PROPERTY(int extraLinesFromCursor READ extraLinesFromCursor CONSTANT)
     Q_PROPERTY(QString charset READ charset CONSTANT)
     Q_PROPERTY(int keyboardMargins READ keyboardMargins CONSTANT)
+    Q_PROPERTY(bool showVisualKeyPressFeedback READ showVisualKeyPressFeedback CONSTANT)
     Q_PROPERTY(int orientationMode READ orientationMode WRITE setOrientationMode NOTIFY orientationModeChanged)
     Q_PROPERTY(bool showWelcomeScreen READ showWelcomeScreen WRITE setShowWelcomeScreen NOTIFY showWelcomeScreenChanged)
     Q_ENUMS(KeyboardMode)
@@ -119,6 +120,8 @@ public:
     int extraLinesFromCursor();
     QString charset();
     int keyboardMargins();
+
+    bool showVisualKeyPressFeedback();
 
     int orientationMode();
     void setOrientationMode(int mode);


### PR DESCRIPTION
I found the visual feedback that happens when you press a key very distracting and it messes a bit with how the tablet redraws the screen. This PR adds a flag for the settings file that can disable this feature. To use it, edit the `/.config/settings.ini` and add:

```
[ui]
showVisualKeyPressFeedback=false
``` 

I personally think this should be the default value, but for now, here's a PR that makes this behavior opt-in.