### PR TITLE
Update QT Creator link to archived version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ Note that Landscape mode doesn't seem to work - this was true when I downloaded 
 
 ## Build instructions
 
-To build and install fingerterm (as well as other projects like [draft](https://github.com/dixonary/draft-reMarkable), you'll first need to setup QT Creator. This is covered on the [reMarkable wiki](https://remarkablewiki.com/devel/qt_creator). After that, it's as simple as opening the project in QT Creator and running it with your reMarkable connected to your computer.
+To build and install fingerterm (as well as other projects like [draft](https://github.com/dixonary/draft-reMarkable), you'll first need to setup QT Creator. This is covered on the [reMarkable wiki](https://web.archive.org/web/20230129161833/https://remarkablewiki.com/devel/qt_creator). After that, it's as simple as opening the project in QT Creator and running it with your reMarkable connected to your computer.


### PR DESCRIPTION
The current link leads to a malicious website and I don't believe is available anywhere directly anymore.